### PR TITLE
Fix API compat version guards

### DIFF
--- a/src/dock-compat.cpp
+++ b/src/dock-compat.cpp
@@ -9,7 +9,7 @@
 
 OBSDock::OBSDock(QMainWindow *main) : QDockWidget(main) {}
 
-#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(29, 1, 3)
+#if LIBOBS_API_VER <= MAKE_SEMANTIC_VERSION(29, 1, 3)
 extern "C"
 bool obs_frontend_add_dock_by_id_compat(const char *id, const char *title, void *widget)
 {

--- a/src/plugin-main.c
+++ b/src/plugin-main.c
@@ -27,7 +27,7 @@ OBS_MODULE_USE_DEFAULT_LOCALE(PLUGIN_NAME, "en-US")
 
 void *create_loudness_dock();
 
-#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(29, 1, 3)
+#if LIBOBS_API_VER <= MAKE_SEMANTIC_VERSION(29, 1, 3)
 bool obs_frontend_add_dock_by_id_compat(const char *id, const char *title, void *widget);
 #define obs_frontend_add_dock_by_id obs_frontend_add_dock_by_id_compat
 #endif


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Fix API compat version guards
29.1.3 should be included

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Try to test build my AUR package (same change but as sed commands).
https://aur.archlinux.org/packages/obs-loudness-dock

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
