### PR TITLE
Fix dock parent window

### DIFF
--- a/src/loudness-dock.cpp
+++ b/src/loudness-dock.cpp
@@ -21,6 +21,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QTimer>
+#include <QMainWindow>
+#include <obs-frontend-api.h>
 #include "plugin-macros.generated.h"
 #include "loudness-dock.hpp"
 
@@ -74,7 +76,8 @@ LoudnessDock::~LoudnessDock()
 
 extern "C" QWidget *create_loudness_dock()
 {
-	return static_cast<QWidget *>(new LoudnessDock());
+	const auto main_window = static_cast<QMainWindow *>(obs_frontend_get_main_window());
+	return static_cast<QWidget *>(new LoudnessDock(main_window));
 }
 
 void LoudnessDock::on_reset()


### PR DESCRIPTION

### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Set a parent window for the dock.

The dock did not have its parent and it resulted in not correctly showing up when starting OBS.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

OS: Fedora 37

Without this PR, a transparent window appears when started OBS but the dock was not displayed.

With this PR, the transparent window does not appear and the loudness dock is displayed.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
