### PR TITLE
.github, src: Update clang-format-18

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Clang
       run: |
-        sudo apt-get install -y clang-format-12
+        sudo apt-get install -y clang-format-18
         clang-format -i -fallback-style=none $(git ls-files | grep -v 'deps/' | grep '\.\(c\|h\)$')
 
     - name: Check

--- a/src/dock-compat.cpp
+++ b/src/dock-compat.cpp
@@ -10,8 +10,7 @@
 OBSDock::OBSDock(QMainWindow *main) : QDockWidget(main) {}
 
 #if LIBOBS_API_VER <= MAKE_SEMANTIC_VERSION(29, 1, 3)
-extern "C"
-bool obs_frontend_add_dock_by_id_compat(const char *id, const char *title, void *widget)
+extern "C" bool obs_frontend_add_dock_by_id_compat(const char *id, const char *title, void *widget)
 {
 	auto *main = (QMainWindow *)obs_frontend_get_main_window();
 	auto *dock = new OBSDock(main);

--- a/src/dock-compat.hpp
+++ b/src/dock-compat.hpp
@@ -4,8 +4,7 @@
 #include <QDockWidget>
 
 // To apply the style for `OBSDock QFrame`, define the class `OBSDock`.
-class OBSDock : public QDockWidget
-{
+class OBSDock : public QDockWidget {
 	Q_OBJECT
 public:
 	OBSDock(QMainWindow *main);


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Update clang-format version from 12 to 18.

The `ubuntu-latest` runner becomes Ubuntu 24.04 and `clang-format-12` is no longer available.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Tested on Fedora.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
