### PR TITLE
Fix vertical align of digits

### DIFF
--- a/src/loudness-dock.cpp
+++ b/src/loudness-dock.cpp
@@ -195,7 +195,7 @@ LoudnessDock::LoudnessDock(QWidget *parent) : QFrame(parent)
 		if (valueLabel) {
 			*valueLabel = new QLabel("-", this);
 			topLayout->addWidget(*valueLabel, row, 1);
-			(*valueLabel)->setAlignment(Qt::AlignRight);
+			(*valueLabel)->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 
 			QFontMetrics metrics((*valueLabel)->font());
 			QRect bounds = metrics.boundingRect(QStringLiteral("%1").arg(-199.0, 2, 'f', 1));


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

This PR fixes the vertical centering was not enabled for the QLabel objects for displaying digits.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

OS: macOS

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
