### PR TITLE
Use thread to process audio data

### DIFF
--- a/src/loudness.c
+++ b/src/loudness.c
@@ -19,6 +19,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <obs-module.h>
 #include <util/threading.h>
+#include <util/darray.h>
 #include "loudness.h"
 #include "ebur128.h"
 #include "plugin-macros.generated.h"
@@ -30,11 +31,15 @@ struct loudness
 	int track;
 	ebur128_state *state;
 	pthread_mutex_t mutex;
+	pthread_cond_t cond;
+	pthread_t thread;
 	float_array_t buf;
 	bool paused;
+	volatile bool cont;
 };
 
 void audio_cb(void *param, size_t mix_idx, struct audio_data *data);
+void *process_thread(void *param);
 
 static bool init_state(loudness_t *loudness)
 {
@@ -65,6 +70,10 @@ loudness_t *loudness_create(int track)
 	}
 
 	pthread_mutex_init(&loudness->mutex, NULL);
+	pthread_cond_init(&loudness->cond, NULL);
+	loudness->cont = true;
+
+	pthread_create(&loudness->thread, NULL, process_thread, loudness);
 
 	obs_add_raw_audio_callback(track, NULL, audio_cb, loudness);
 
@@ -77,8 +86,18 @@ void loudness_destroy(loudness_t *loudness)
 		return;
 
 	obs_remove_raw_audio_callback(loudness->track, audio_cb, loudness);
+
+	pthread_mutex_lock(&loudness->mutex);
+	loudness->cont = false;
+	pthread_cond_signal(&loudness->cond);
+	pthread_mutex_unlock(&loudness->mutex);
+
+	pthread_join(loudness->thread, NULL);
+
 	if (loudness->state)
 		ebur128_destroy(&loudness->state);
+
+	pthread_cond_destroy(&loudness->cond);
 	pthread_mutex_destroy(&loudness->mutex);
 	da_free(loudness->buf);
 	bfree(loudness);
@@ -122,13 +141,10 @@ void loudness_get(loudness_t *loudness, double results[5], uint32_t flags)
 #endif
 }
 
-#ifdef ENABLE_PROFILE
-static const char *name_audio_cb = "loudness-audio_cb";
-#endif
-
 void audio_cb(void *param, size_t mix_idx, struct audio_data *data)
 {
 #ifdef ENABLE_PROFILE
+	static const char *name_audio_cb = "loudness-audio_cb";
 	profile_start(name_audio_cb);
 #endif
 
@@ -139,16 +155,17 @@ void audio_cb(void *param, size_t mix_idx, struct audio_data *data)
 
 	if (loudness->state) {
 		const size_t nch = loudness->state->channels;
-		da_resize(loudness->buf, nch * data->frames);
+		size_t offset = loudness->buf.num;
+		da_resize(loudness->buf, offset + nch * data->frames);
 
-		float *array = loudness->buf.array;
+		float *array = offset + loudness->buf.array;
 		const float **data_in = (const float **)data->data;
 		for (size_t iframe = 0, k = 0; iframe < data->frames; iframe++) {
 			for (size_t ich = 0; ich < nch; ich++)
 				array[k++] = data_in[ich][iframe];
 		}
 
-		ebur128_add_frames_float(loudness->state, array, data->frames);
+		pthread_cond_signal(&loudness->cond);
 	}
 
 	pthread_mutex_unlock(&loudness->mutex);
@@ -156,6 +173,43 @@ void audio_cb(void *param, size_t mix_idx, struct audio_data *data)
 #ifdef ENABLE_PROFILE
 	profile_end(name_audio_cb);
 #endif
+}
+
+void *process_thread(void *param)
+{
+#ifdef ENABLE_PROFILE
+	static const char *name_ebur128_add_frames = "ebur128_add_frames";
+#endif
+	loudness_t *loudness = param;
+
+	os_set_thread_name("loudness");
+
+	pthread_mutex_lock(&loudness->mutex);
+
+	while (loudness->cont) {
+		pthread_cond_wait(&loudness->cond, &loudness->mutex);
+
+		if (!loudness->buf.num)
+			continue;
+
+#ifdef ENABLE_PROFILE
+		profile_start(name_ebur128_add_frames);
+#endif
+		size_t frames = loudness->buf.num / loudness->state->channels;
+		ebur128_add_frames_float(loudness->state, loudness->buf.array, frames);
+#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(30, 0, 0)
+		loudness->buf.num = 0;
+#else
+		da_clear(loudness->buf);
+#endif
+#ifdef ENABLE_PROFILE
+		profile_end(name_ebur128_add_frames);
+#endif
+	}
+
+	pthread_mutex_unlock(&loudness->mutex);
+
+	return NULL;
 }
 
 int loudness_track(const loudness_t *loudness)


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Recently, we implemented tabs, which will increase the time in the libobs audio thread.
To avoid the load in the audio thread, create a separated thread to process loudness calculation.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Tested on macOS (M2), OBS 32.0.4.

Audio: a 442 Hz sine wave, stereo.
Dock: 2 tabs.


Without this PR:
```txt
audio_thread(Audio): min=0.002 ms, median=1.189 ms, max=6.031 ms, 99th percentile=4.612 ms
 ┗loudness-audio_cb: min=0.122 ms, median=0.538 ms, max=3.707 ms, 99th percentile=2.417 ms, 1.9443 calls per parent call
SingleMeter::paintEvent: min=0.001 ms, median=0.004 ms, max=3.871 ms, 99th percentile=3.871 ms
on_timer: min=0.406 ms, median=1.673 ms, max=3.693 ms, 99th percentile=3.493 ms
 ┗loudness_get: min=0.398 ms, median=1.65 ms, max=3.674 ms, 99th percentile=3.47 ms
```

With this PR:
```txt
audio_thread(Audio): min=0.002 ms, median=0.109 ms, max=3.198 ms, 99th percentile=2.063 ms
 ┗loudness-audio_cb: min=0.002 ms, median=0.015 ms, max=3.082 ms, 99th percentile=1.366 ms, 1.94395 calls per parent call
ebur128_add_frames: min=0.133 ms, median=0.851 ms, max=4.066 ms, 99th percentile=2.839 ms
SingleMeter::paintEvent: min=0.001 ms, median=0.003 ms, max=3.717 ms, 99th percentile=3.717 ms
on_timer: min=0.413 ms, median=1.639 ms, max=3.854 ms, 99th percentile=3.453 ms
 ┗loudness_get: min=0.411 ms, median=1.621 ms, max=3.839 ms, 99th percentile=3.437 ms
```

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
