### PR TITLE
Remove mutex in LoudnessDock

### DIFF
--- a/src/loudness-dock.cpp
+++ b/src/loudness-dock.cpp
@@ -388,16 +388,12 @@ void LoudnessDock::on_timer()
 	else
 		update_count++;
 
-	std::unique_lock<std::mutex> lock(results_mutex);
-
 	loudness_get(loudness, results, flags);
 
 	for (auto &r : results) {
 		if (r < -192.0)
 			r = -HUGE_VAL;
 	}
-
-	lock.unlock();
 
 	if (flags & LOUDNESS_GET_SHORT) {
 		if (update_count % 4 == 0) {
@@ -470,8 +466,6 @@ void LoudnessDock::apply_move_config(loudness_dock_config_s &cfg)
 		label_range->hide();
 		label_peak->hide();
 	}
-
-	std::unique_lock<std::mutex> lock(results_mutex);
 
 	for (uint32_t i = 0; i < cfg.tabs.size() && (int)cfg.tabs.size() > tabbar->count(); i++) {
 		const auto &tab = cfg.tabs[i];
@@ -599,7 +593,6 @@ void LoudnessDock::ws_get_loudness_cb(obs_data_t *request, obs_data_t *response)
 		return;
 	}
 
-	std::unique_lock<std::mutex> lock(results_mutex);
 	ws_loudness_set_response(response, results);
 }
 
@@ -751,8 +744,6 @@ void LoudnessDock::on_frontend_event(enum obs_frontend_event event, void *data)
 loudness_t *LoudnessDock::get_by_name(const char *name)
 {
 	ASSERT_THREAD(OBS_TASK_UI);
-
-	std::unique_lock<std::mutex> lock(results_mutex);
 
 	for (size_t i = 0; i < config.tabs.size(); i++) {
 		if (config.tabs[i].name == name)

--- a/src/loudness-dock.hpp
+++ b/src/loudness-dock.hpp
@@ -45,18 +45,11 @@ private:
 
 	QPointer<class ConfigDialog> dialog;
 
-	std::mutex results_mutex;
 	double results[5];
 
 	bool frontend_exited = false;
 
 private:
-	/* For EBU R 128 processing
-	 * Written by UI thread only.
-	 * Can be read from other threads.
-	 * UI thread will lock `results_mutex` while writing.
-	 * Other threads need to lock when reading.
-	 * */
 	std::vector<loudness_t *> ll;
 	int ix_ll = 0;
 	uint32_t update_count = 0;


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

The PR removes a mutex `results_mutex`.

Now the `results` and other data are always accessed from the UI thread. Hence, the mutex is no longer required.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Checked by eyeballs; all guarded code blocks are running in the UI thread.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [ ] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
