### PR TITLE
Add websocket interface to list names of tabs

### DIFF
--- a/example/get_loudness.py
+++ b/example/get_loudness.py
@@ -11,6 +11,7 @@ def _get_args():
     parser.add_argument('-r', '--reset', action='store_true')
     parser.add_argument('-p', '--pause', action='store_true')
     parser.add_argument('-s', '--resume', action='store_true')
+    parser.add_argument('-l', '--list-names', action='store_true')
     parser.add_argument('--name', action='store', default=None)
     return parser.parse_args()
 
@@ -22,6 +23,14 @@ def _main():
     data = {}
     if args.name:
         data['name'] = args.name
+
+    if args.list_names:
+        res = cl.send('CallVendorRequest', {
+            'vendorName': 'loudness-dock',
+            'requestType': 'get_names',
+        })
+        print(res.response_data)
+        return
 
     if args.pause:
         cl.send('CallVendorRequest', {

--- a/src/loudness-dock.cpp
+++ b/src/loudness-dock.cpp
@@ -269,6 +269,7 @@ LoudnessDock::LoudnessDock(QWidget *parent) : QFrame(parent)
 		obs_websocket_vendor_register_request(ws_vendor, "get_loudness", ws_get_loudness_cb, this);
 		obs_websocket_vendor_register_request(ws_vendor, "reset", ws_reset_cb, this);
 		obs_websocket_vendor_register_request(ws_vendor, "pause", ws_pause_cb, this);
+		obs_websocket_vendor_register_request(ws_vendor, "get_names", ws_get_names_cb, this);
 	}
 	if (ws_vendor_compat) {
 		obs_websocket_vendor_register_request(ws_vendor_compat, "get_loudness", ws_compat_get_loudness_cb,
@@ -630,6 +631,29 @@ void LoudnessDock::ws_pause_cb(obs_data_t *request, obs_data_t *, void *priv_dat
 			ld->on_pause(p);
 		}
 	});
+}
+
+void LoudnessDock::ws_get_names_cb(obs_data_t *, obs_data_t *response, void *priv_data)
+{
+	auto ld = static_cast<LoudnessDock *>(priv_data);
+
+	obs_data_array_t *names = obs_data_array_create();
+
+	run_in_ui_and_wait([ld, names]() { ld->ws_get_names_cb(names); });
+
+	obs_data_set_array(response, "names", names);
+	obs_data_array_release(names);
+}
+
+void LoudnessDock::ws_get_names_cb(obs_data_array_t *names)
+{
+	ASSERT_THREAD(OBS_TASK_UI);
+
+	for (size_t i = 0; i < config.tabs.size(); i++) {
+		obs_data_t *item = obs_data_create();
+		obs_data_set_string(item, "name", config.tabs[i].name.c_str());
+		obs_data_array_push_back(names, item);
+	}
 }
 
 void LoudnessDock::ws_compat_get_loudness_cb(obs_data_t *request, obs_data_t *response, void *priv_data)

--- a/src/loudness-dock.hpp
+++ b/src/loudness-dock.hpp
@@ -74,6 +74,8 @@ private:
 	void ws_get_loudness_cb(obs_data_t *, obs_data_t *);
 	static void ws_reset_cb(obs_data_t *, obs_data_t *, void *);
 	static void ws_pause_cb(obs_data_t *, obs_data_t *, void *);
+	static void ws_get_names_cb(obs_data_t *, obs_data_t *, void *);
+	void ws_get_names_cb(obs_data_array_t *names);
 
 	static void ws_compat_get_loudness_cb(obs_data_t *, obs_data_t *, void *);
 	static void ws_compat_reset_cb(obs_data_t *, obs_data_t *, void *);


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Adds websocket interface to list names of tabs. This will allow scripts to display all loudness values.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Tested with the example script.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
