### PR TITLE
Add frame counter on websocket API

### DIFF
--- a/example/get_loudness.py
+++ b/example/get_loudness.py
@@ -12,6 +12,7 @@ def _get_args():
     parser.add_argument('-p', '--pause', action='store_true')
     parser.add_argument('-s', '--resume', action='store_true')
     parser.add_argument('-l', '--list-names', action='store_true')
+    parser.add_argument('-v', '--verbose', action='store_true')
     parser.add_argument('--name', action='store', default=None)
     return parser.parse_args()
 
@@ -54,6 +55,8 @@ def _main():
         })
 
     if not (args.pause or args.resume or args.reset):
+        if args.verbose:
+            data |= {'verbose': True}
         res = cl.send('CallVendorRequest', {
             'vendorName': 'loudness-dock',
             'requestType': 'get_loudness',
@@ -64,6 +67,9 @@ def _main():
             if value is None:
                 value = float('-inf')
             print(f'{field}: {value:.1f}')
+        if args.verbose:
+            print(f'duration: {res.response_data["duration"]:.1f}')
+            print(f'paused: {res.response_data["paused"]}')
 
 
 if __name__ == '__main__':

--- a/src/loudness-dock.cpp
+++ b/src/loudness-dock.cpp
@@ -577,27 +577,38 @@ void LoudnessDock::ws_get_loudness_cb(obs_data_t *request, obs_data_t *response,
 	run_in_ui_and_wait([ld, request, response]() { ld->ws_get_loudness_cb(request, response); });
 }
 
-static void ws_loudness_set_response(obs_data_t *response, double results[5])
+static void ws_loudness_set_response(obs_data_t *response, const loudness_t *loudness, double results[5])
 {
 	obs_data_set_double(response, "momentary", results[0]);
 	obs_data_set_double(response, "short", results[1]);
 	obs_data_set_double(response, "integrated", results[2]);
 	obs_data_set_double(response, "range", results[3]);
 	obs_data_set_double(response, "peak", results[4]);
+
+	if (loudness) {
+		obs_data_set_bool(response, "paused", loudness_paused(loudness));
+
+		struct obs_audio_info oai;
+		if (!obs_get_audio_info(&oai) || oai.samples_per_sec <= 0)
+			return;
+		obs_data_set_double(response, "duration", loudness_frames(loudness) / (double)oai.samples_per_sec);
+	}
 }
 
 void LoudnessDock::ws_get_loudness_cb(obs_data_t *request, obs_data_t *response)
 {
 	ASSERT_THREAD(OBS_TASK_UI);
 
+	bool verbose = obs_data_get_bool(request, "verbose");
+
 	if (loudness_t *loudness = get_by_name_in_data(request)) {
 		double res[5];
 		loudness_get(loudness, res, LOUDNESS_GET_SHORT | LOUDNESS_GET_LONG);
-		ws_loudness_set_response(response, res);
+		ws_loudness_set_response(response, verbose ? loudness : nullptr, res);
 		return;
 	}
 
-	ws_loudness_set_response(response, results);
+	ws_loudness_set_response(response, verbose ? get() : nullptr, results);
 }
 
 void LoudnessDock::ws_reset_cb(obs_data_t *request, obs_data_t *, void *priv_data)

--- a/src/loudness.c
+++ b/src/loudness.c
@@ -30,6 +30,7 @@ struct loudness
 {
 	int track;
 	ebur128_state *state;
+	size_t frames;
 	pthread_mutex_t mutex;
 	pthread_cond_t cond;
 	pthread_t thread;
@@ -48,6 +49,8 @@ static bool init_state(loudness_t *loudness)
 		blog(LOG_ERROR, "obs_get_audio_info failed");
 		return false;
 	}
+
+	loudness->frames = 0;
 
 	int mode = EBUR128_MODE_M | EBUR128_MODE_S | EBUR128_MODE_I | EBUR128_MODE_LRA | EBUR128_MODE_TRUE_PEAK;
 	loudness->state = ebur128_init(get_audio_channels(oai.speakers), oai.samples_per_sec, mode);
@@ -197,6 +200,7 @@ void *process_thread(void *param)
 #endif
 		size_t frames = loudness->buf.num / loudness->state->channels;
 		ebur128_add_frames_float(loudness->state, loudness->buf.array, frames);
+		loudness->frames += frames;
 		loudness->buf.num = 0; // equivalent to `da_clear` but requires LIBOBS_API_VER >= 30.0.0
 #ifdef ENABLE_PROFILE
 		profile_end(name_ebur128_add_frames);
@@ -242,4 +246,9 @@ void loudness_reset(loudness_t *loudness)
 	init_state(loudness);
 
 	pthread_mutex_unlock(&loudness->mutex);
+}
+
+size_t loudness_frames(const loudness_t *loudness)
+{
+	return loudness->frames;
 }

--- a/src/loudness.h
+++ b/src/loudness.h
@@ -30,6 +30,7 @@ int loudness_track(const loudness_t *loudness);
 void loudness_set_pause(loudness_t *loudness, bool paused);
 bool loudness_paused(const loudness_t *loudness);
 void loudness_reset(loudness_t *loudness);
+size_t loudness_frames(const loudness_t *loudness);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Adds frame counter and pause-state returned through the websocket API.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [ ] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
